### PR TITLE
Fixing off-by-one error with function extraction

### DIFF
--- a/generate_specs.py
+++ b/generate_specs.py
@@ -56,7 +56,7 @@ def extract_func(filename, func_analysis):
     with open(filename, 'r') as f:
         lines = f.readlines()
 
-    func_lines = lines[start_line-1:end_line]
+    func_lines = lines[start_line-1:end_line+1]
     func_lines[0] = func_lines[0][start_col-1:]
     func_lines[-1] = func_lines[-1][:end_col-1]
 


### PR DESCRIPTION
I think there was an off-by-one issue with `extract_func`.

Before this change:
```
Processing function swap...
void swap(int* a, int* b)
{
    int t = *a;
    *a = *b;
    *b = t;
```

After this change:
```
Processing function swap...
void swap(int* a, int* b)
{
    int t = *a;
    *a = *b;
    *b = t;
}
```

The last line (curly brace) was omitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected function content extraction to include the full body, preventing the last line from being omitted.
  * Improves accuracy of generated outputs (e.g., specs, previews) by capturing complete function boundaries.
  * Reduces edge-case truncation issues and inconsistencies in downstream processing and comparisons.
  * Enhances overall reliability without affecting other behaviors or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->