### PR TITLE
Adding `tree-sitter` and `tree-sitter-rust` to `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ networkx
 pytest>=8.4.2
 lark>=1.3.0
 loguru>=0.7.3
+tree-sitter==0.25.2
+tree-sitter-rust==0.24.0


### PR DESCRIPTION
@vikramnitin9 There is currently a build error with `ParseRust` (it needs a version of `rustc` that is incompatible with Kani).

I will attempt to use `tree-sitter` first and migrate to `ParseRust` if necessary.