### PR TITLE
Disabling automatic CodeRabbit reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -20,6 +20,7 @@ reviews:
     - "!**/node_modules/**"
     - "!verification-algorithm.md"
   auto_review:
+    enabled: false
     ignore_title_keywords:
       - "wip"
       - "draft"


### PR DESCRIPTION
I am proposing we disable the CodeRabbit feature that _automatically_ reviews any PR, and keeps reviewing it every time a commit is made. I am effectively doing this manually by commenting `@CodeRabbit pause`.

CodeRabbit reviews are helpful. However, they are not helpful when a deluge of new comments is made every time I push a commit.

I would like to manually invoke CodeRabbit once a PR is relatively stable (i.e., the rate of new pushes slow down). 