### PR TITLE
Specifying valid JSON and schema in prompts

### DIFF
--- a/prompts/generate-specifications-prompt-template.txt
+++ b/prompts/generate-specifications-prompt-template.txt
@@ -884,7 +884,7 @@ __CPROVER_ensures((__CPROVER_return_value == FAILURE) ==> (*out == __CPROVER_old
 __CPROVER_ensures(*out > 0)
 __CPROVER_assigns(*out)
 
-Your response will be in the following format:
+Your response is in valid JSON with the following schema:
 
 {
   "preconditions": [...],

--- a/prompts/generate-specifications-prompt-with-expressions-template.txt
+++ b/prompts/generate-specifications-prompt-with-expressions-template.txt
@@ -884,7 +884,7 @@ __CPROVER_ensures((__CPROVER_return_value == FAILURE) ==> (*out == __CPROVER_old
 __CPROVER_ensures(*out > 0)
 __CPROVER_assigns(*out)
 
-Your response will be in the following format:
+Your response is in valid JSON with the following schema:
 
 {
   "precondition_expressions": [...],

--- a/prompts/next-step-prompt-template.txt
+++ b/prompts/next-step-prompt-template.txt
@@ -21,13 +21,13 @@ specification that verifies for $function_name.
 
 </KEY POINTS>
 
-If you choose (1), your response should be in the following format:
+If you choose (1), your response is in valid JSON with the following schema:
 
 {
     "next_step": "ASSUME_SPEC_AS_IS"
 }
 
-If you choose (2), your response should be in the following format:
+If you choose (2), your response is in valid JSON with the following schema:
 
 {
     "next_step": "BACKTRACK_TO_CALLEE",

--- a/prompts/repair-specifications-prompt-template.txt
+++ b/prompts/repair-specifications-prompt-template.txt
@@ -13,7 +13,7 @@ Here's the current implementation of $function_name:
 
 $function_implementation
 
-Your response is in the following format:
+Your response is in valid JSON with the following schema:
 
 {
     "preconditions": [...],

--- a/prompts/repair-specifications-prompt-with-expressions-template.txt
+++ b/prompts/repair-specifications-prompt-with-expressions-template.txt
@@ -13,7 +13,7 @@ Here's the current implementation of $function_name:
 
 $function_implementation
 
-Your response is in the following format:
+Your response is in valid JSON with the following schema:
 
 {
   "precondition_expressions": [...],


### PR DESCRIPTION
GPT-4o appears to love putting `//` comments in the response JSON.