### PR TITLE
Adding `--skip-verified-cached-functions` flag

### DIFF
--- a/main.py
+++ b/main.py
@@ -140,6 +140,14 @@ def main() -> None:
         choices=[granularity.value for granularity in SpecGenGranularity],
         help=("The granularity at which specification generation occurs (defaults to clauses)."),
     )
+    parser.add_argument(
+        "--skip-verified-cached-functions",
+        action="store_true",
+        help=(
+            "Do not add functions for which there are verified and cached specifications to the "
+            "workstack of functions. (defaults to False)"
+        ),
+    )
     args = parser.parse_args()
 
     input_file_path = Path(args.file)
@@ -171,6 +179,7 @@ def main() -> None:
             _verify_program,
             parsec_file,
             specification_generator,
+            args.skip_verified_cached_functions,
             timeout_sec=args.specification_generation_timeout_sec,
         )
     except TimeoutError as te:
@@ -183,6 +192,7 @@ def main() -> None:
 def _verify_program(
     parsec_file: ParsecFile,
     specification_generator: LlmSpecificationGenerator,
+    skip_verified_cached_functions: bool,
 ) -> tuple[ProofState, ...]:
     """Return a set of ProofStates, each of which has a specification for each function.
 
@@ -192,6 +202,9 @@ def _verify_program(
     Args:
         parsec_file (ParsecFile): The file to verify.
         specification_generator (LlmSpecificationGenerator): The LLM specification generator.
+        skip_verified_cached_functions (bool): True iff functions that have verified and cached
+            specifications should not be added to the workstack of functions for which to generate
+            specs.
 
     Returns:
         tuple[ProofState, ...]: A set of ProofStates, each of which has specifications for each
@@ -201,6 +214,15 @@ def _verify_program(
     # Since the initial list of functions is in reverse topological order,
     # the first element processed will be a leaf.
     functions = parsec_file.get_functions_in_topological_order()
+
+    if skip_verified_cached_functions:
+        functions = [f for f in functions if not _is_verified_and_cached(f)]
+
+    if not functions:
+        # There are specs in the cache for all the functions.
+        # How should we re-construct ProofStates from the cache?
+        sys.exit(0)
+
     initial_proof_state = ProofState.from_functions(functions=functions)
     GLOBAL_OBSERVED_PROOFSTATES.add(initial_proof_state)
     # This is the global worklist.
@@ -442,6 +464,25 @@ def _get_result_file(function: CFunction) -> Path:
     pid_dir = Path(str(os.getpid()))
     result_file_dir = Path(DEFAULT_RESULT_DIR) / pid_dir / Path(original_file_dir)
     return result_file_dir / path_to_original_file.name
+
+
+def _is_verified_and_cached(function: CFunction) -> bool:
+    """Return True iff the function has a verified and cached specification.
+
+    Args:
+        function (CFunction): The function for which to check for a verified and cached
+            specification.
+
+    Returns:
+        bool: True iff the function has a verified and cached specification.
+    """
+    for vinput in VERIFIER_CACHE.iterkeys():
+        # This is very inefficient, but still faster than adding all the functions to workstacks
+        # and reading from the cache repeatedly.
+        vresult = VERIFIER_CACHE[vinput]
+        if vresult.succeeded and vresult.get_function() == function:
+            return True
+    return False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I am having to re-start specification generation after a timeout.

However, attempting to verify/read the cache for functions that have already been processed before the timeout takes a non-trivial amount of time (often a large chunk of the timeout).

Passing `--skip-verified-cached-functions` on the command line effectively re-starts specification generation from the first function without a verified and cached specification.