### PR TITLE
Introducing `VerificationState` for verification results

### DIFF
--- a/eval/get_verification_summary.py
+++ b/eval/get_verification_summary.py
@@ -21,7 +21,7 @@ from dataclasses import asdict, dataclass
 
 from eval import ClauseComplexity, get_complexity
 from util import CFunction, CFunctionGraph, FunctionSpecification, get_destination_path
-from verification import VerificationResult
+from verification import VerificationResult, VerificationStatus
 
 
 class StaleCacheEntryError(Exception):
@@ -85,12 +85,14 @@ class VerificationSummary:
     Attributes:
         function_name (str): The name of the function.
         verifying_specs (list[SpecWithComplexity]): The list of verifying specs with complexity.
+        assumed_specs (list[SpecWithComplexity]): The list of assumed specs with complexity.
         failing_specs (list[SpecWithComplexity]): The list of failing specs with complexity.
         stale_cache_entries (list[StaleCacheEntryError]): The list of stale cache entry errors.
     """
 
     function_name: str
     verifying_specs: list[SpecWithComplexity]
+    assumed_specs: list[SpecWithComplexity]
     failing_specs: list[SpecWithComplexity]
     stale_cache_entries: list[StaleCacheEntryError]
 
@@ -105,7 +107,13 @@ class VerificationSummary:
         Returns:
             VerificationSummary: An empty verification summary.
         """
-        return cls(function_name, verifying_specs=[], failing_specs=[], stale_cache_entries=[])
+        return cls(
+            function_name,
+            verifying_specs=[],
+            assumed_specs=[],
+            failing_specs=[],
+            stale_cache_entries=[],
+        )
 
     def to_dict(self) -> dict[str, Any]:
         """Return the dictionary representation of this verification summary.
@@ -289,6 +297,7 @@ def _get_verification_summary(
         VerificationSummary: The verification summary for the function.
     """
     verifying_specs = []
+    assumed_specs = []
     failing_specs = []
     lookup_errors = []
     for result in lookup_result.results:
@@ -296,13 +305,18 @@ def _get_verification_summary(
             spec_with_complexity = SpecWithComplexity(
                 result.get_spec(), *_get_complexity_for_clauses(result.get_spec())
             )
-            if result.succeeded:
-                verifying_specs.append(spec_with_complexity)
-            else:
-                failing_specs.append(spec_with_complexity)
+            match result.status:
+                case VerificationStatus.SUCCEEDED:
+                    verifying_specs.append(spec_with_complexity)
+                case VerificationStatus.ASSUMED:
+                    assumed_specs.append(spec_with_complexity)
+                case VerificationStatus.FAILED:
+                    failing_specs.append(spec_with_complexity)
         else:
             lookup_errors.append(result)
-    return VerificationSummary(function.name, verifying_specs, failing_specs, lookup_errors)
+    return VerificationSummary(
+        function.name, verifying_specs, assumed_specs, failing_specs, lookup_errors
+    )
 
 
 def _get_result_json_name(c_file: str) -> Path:

--- a/eval/get_verification_summary.py
+++ b/eval/get_verification_summary.py
@@ -203,6 +203,7 @@ def main() -> None:
         else:
             merged_summaries[function_name]["verifying_specs"].extend(vsummary["verifying_specs"])
             merged_summaries[function_name]["failing_specs"].extend(vsummary["failing_specs"])
+            merged_summaries[function_name]["assumed_specs"].extend(vsummary["assumed_specs"])
             merged_summaries[function_name]["lookup_errors"].extend(vsummary["lookup_errors"])
     verification_summary_for_file["functions"] = list(merged_summaries.values())
 

--- a/main.py
+++ b/main.py
@@ -298,7 +298,9 @@ def _verify_program(
     # This is the global worklist.
     GLOBAL_INCOMPLETE_PROOFSTATES.append(initial_proof_state)
 
-    proof_state_stepper = ProofStateStepper(result_dir=Path(DEFAULT_RESULT_DIR))
+    proof_state_stepper = ProofStateStepper(
+        result_dir=Path(DEFAULT_RESULT_DIR), cache=VERIFIER_CACHE
+    )
 
     while GLOBAL_INCOMPLETE_PROOFSTATES:
         # Use BFS to avoid getting stuck in an unproductive search over a proof state.

--- a/verification/__init__.py
+++ b/verification/__init__.py
@@ -7,7 +7,7 @@ from .proof_state import ProofState, WorkItem, WorkStack
 from .proof_state_stepper import ProofStateStepper
 from .verification_client import VerificationClient
 from .verification_input import VerificationContext, VerificationInput
-from .verification_result import VerificationResult
+from .verification_result import VerificationResult, VerificationStatus
 
 __all__ = [
     "AVOCADO_STUB_DIR",
@@ -25,6 +25,7 @@ __all__ = [
     "VerificationContext",
     "VerificationInput",
     "VerificationResult",
+    "VerificationStatus",
     "WorkItem",
     "WorkStack",
     "get_stub_mappings",

--- a/verification/cbmc_verification_client.py
+++ b/verification/cbmc_verification_client.py
@@ -9,7 +9,7 @@ from diskcache import Cache
 from loguru import logger
 
 from util import file_util, text_util
-from verification.verification_result import VerificationResult
+from verification.verification_result import VerificationResult, VerificationStatus
 
 from .avocado_stub_util import AVOCADO_STUB_DIR
 from .verification_client import VerificationClient
@@ -60,10 +60,13 @@ class CbmcVerificationClient(VerificationClient):
             logger.debug(f"Caching vresult for: {vinput.function}")
             self._cache[vinput] = vresult
 
-        if vresult.succeeded:
-            logger.success(f"Verification succeeded for function '{vinput.function.name}'")
-        else:
-            logger.error(f"Verification failed for function '{vinput.function.name}'")
+        match vresult.status:
+            case VerificationStatus.SUCCEEDED:
+                logger.success(f"Verification succeeded for function '{vinput.function.name}'")
+            case VerificationStatus.ASSUMED:
+                logger.warning(f"Verification assumed for function '{vinput.function.name}'")
+            case VerificationStatus.FAILED:
+                logger.error(f"Verification failed for function '{vinput.function.name}'")
         return vresult
 
     def _run_verifier(self, vinput: VerificationInput) -> VerificationResult:
@@ -95,7 +98,9 @@ class CbmcVerificationClient(VerificationClient):
                 return VerificationResult(
                     vinput,
                     vcommand,
-                    succeeded=result.returncode == 0,
+                    status=VerificationStatus.SUCCEEDED
+                    if result.returncode == 0
+                    else VerificationStatus.FAILED,
                     stdout=normalized_stdout,
                     stderr=normalized_stderr,
                 )

--- a/verification/proof_state_stepper.py
+++ b/verification/proof_state_stepper.py
@@ -4,6 +4,7 @@ import os
 import shutil
 from pathlib import Path
 
+from diskcache import Cache
 from loguru import logger
 
 from util import (
@@ -15,22 +16,28 @@ from util import (
     SpecConversation,
     function_util,
 )
+from verification.verification_input import VerificationInput
 
 from .proof_state import ProofState, WorkItem
+from .verification_result import VerificationResult, VerificationStatus
 
 
 class ProofStateStepper:
     """Class for creating new proof state(s) based on a SpecConversation and a previous proof state.
 
     Attributes:
-        result_dir (Path): The root directory under which verified/assumed specs are written.
+        _result_dir (Path): The root directory under which verified/assumed specs are written.
+        _cache (Cache | None): The verifier cache. When set, the status of assumed specs is updated
+            to `VerificationStatus.ASSUMED` in the cache.
     """
 
     _result_dir: Path
+    _cache: Cache | None
 
-    def __init__(self, result_dir: Path) -> None:
+    def __init__(self, result_dir: Path, cache: Cache | None = None) -> None:
         """Create a new ProofStateStepper."""
         self._result_dir = result_dir
+        self._cache = cache
 
     def get_next_proof_state(
         self,
@@ -70,6 +77,11 @@ class ProofStateStepper:
                 # There could be more than one valid specification generated (i.e., when we sample
                 # more than once from the LLM). For now, we take the last (valid) specification and
                 # write it to disk (see below).
+                if isinstance(spec_conversation.next_step, AssumeSpecAsIs):
+                    self._update_cache_for_assumed_spec(
+                        specc=spec_conversation,
+                        prev_proof_state=prev_proof_state,
+                    )
                 self._write_spec_to_disk(spec_conversation=spec_conversation)
                 workstack_for_next_proof_state = prev_proof_state.get_workstack().pop()
                 return ProofState(
@@ -102,6 +114,34 @@ class ProofStateStepper:
             case _:
                 msg = f"Unexpected next step strategy: '{spec_conversation.next_step}'"
                 raise ValueError(msg)
+
+    def _update_cache_for_assumed_spec(
+        self, specc: SpecConversation, prev_proof_state: ProofState
+    ) -> None:
+        """Update the cache entry for the given spec to `VerificationStatus.ASSUMED`.
+
+        This is called when a spec is assumed (i.e., accepted without successful verification). The
+        existing cache entry for this spec is updated to reflect that outcome.
+
+        Args:
+            specc (SpecConversation): The spec conversation whose spec is being assumed.
+            prev_proof_state (ProofState): The proof state in which the spec was assumed, used to
+                reconstruct the `VerificationInput` key.
+        """
+        if self._cache is None:
+            return
+        vcontext = prev_proof_state.get_current_context(specc.function)
+        vinput = VerificationInput(
+            specc.function, specc.specification, vcontext, specc.contents_of_file_to_verify
+        )
+        if (vresult := self._cache.get(vinput)) is not None:
+            self._cache[vinput] = VerificationResult(
+                verification_input=vresult.verification_input,
+                verification_command=vresult.verification_command,
+                status=VerificationStatus.ASSUMED,
+                stdout=vresult.stdout,
+                stderr=vresult.stderr,
+            )
 
     def _write_spec_to_disk(self, spec_conversation: SpecConversation) -> None:
         """Write a single function specification to a file on disk.

--- a/verification/proof_state_stepper.py
+++ b/verification/proof_state_stepper.py
@@ -77,12 +77,12 @@ class ProofStateStepper:
                 # There could be more than one valid specification generated (i.e., when we sample
                 # more than once from the LLM). For now, we take the last (valid) specification and
                 # write it to disk (see below).
+                self._write_spec_to_disk(spec_conversation=spec_conversation)
                 if isinstance(spec_conversation.next_step, AssumeSpecAsIs):
                     self._update_cache_for_assumed_spec(
                         specc=spec_conversation,
                         prev_proof_state=prev_proof_state,
                     )
-                self._write_spec_to_disk(spec_conversation=spec_conversation)
                 workstack_for_next_proof_state = prev_proof_state.get_workstack().pop()
                 return ProofState(
                     specs=specs_for_next_proof_state,

--- a/verification/proof_state_stepper.py
+++ b/verification/proof_state_stepper.py
@@ -104,7 +104,10 @@ class ProofStateStepper:
                 )
                 # Since backtracking is not possible, assume the (failing) specs here, and move to
                 # the next function to verify.
+                spec_conversation.next_step = AssumeSpecAsIs()
                 self._write_spec_to_disk(spec_conversation=spec_conversation)
+                self._update_cache_for_assumed_spec(spec_conversation, prev_proof_state)
+
                 workstack_for_next_proof_state = prev_proof_state.get_workstack().pop()
                 return ProofState(
                     specs=specs_for_next_proof_state,

--- a/verification/proof_state_stepper.py
+++ b/verification/proof_state_stepper.py
@@ -134,7 +134,7 @@ class ProofStateStepper:
         vinput = VerificationInput(
             specc.function, specc.specification, vcontext, specc.contents_of_file_to_verify
         )
-        if (vresult := self._cache.get(vinput)) is not None:
+        if vresult := self._cache.get(vinput):
             self._cache[vinput] = VerificationResult(
                 verification_input=vresult.verification_input,
                 verification_command=vresult.verification_command,

--- a/verification/verification_result.py
+++ b/verification/verification_result.py
@@ -1,10 +1,29 @@
 """Class representing a verification result."""
 
 from dataclasses import dataclass
+from enum import StrEnum
 
 from util import CFunction, FunctionSpecification
 
 from .verification_input import VerificationInput
+
+
+class VerificationStatus(StrEnum):
+    """Enum representing the outcome of a verification run.
+
+    SUCCEEDED and FAILED refer to cases when a specification is successfully verified (or fails to
+    verify). A specification can be ASSUMED when:
+
+        1. It is the result of generating a spec for an external callee. For example, this might
+           occur when a spec is generated for a CBMC stub function (see the functions in the .c
+           files in verification/cbmc_stubs/).
+        2. It is the result of generating a spec for a self-recursive function.
+
+    """
+
+    SUCCEEDED = "succeeded"
+    ASSUMED = "assumed"
+    FAILED = "failed"
 
 
 @dataclass(frozen=True)
@@ -14,16 +33,25 @@ class VerificationResult:
     Attributes:
         verification_input (VerificationInput): The input that resulted in this verification result.
         verification_command: The command used to invoke the verifier.
-        succeeded (bool): True iff the input for this verification result successfully verified.
-        failure_messages (str | None): Any failure messages for this verification result, if its
-            input failed verification.
+        status (VerificationStatus): The outcome of this verification run.
+        stdout (str): The standard output of the verifier.
+        stderr (str): The standard error of the verifier.
     """
 
     verification_input: VerificationInput
     verification_command: str
-    succeeded: bool
+    status: VerificationStatus
     stdout: str
     stderr: str
+
+    @property
+    def succeeded(self) -> bool:
+        """Return True iff this verification result has status `SUCCEEDED`.
+
+        Returns:
+            bool: True iff this verification result has status `SUCCEEDED`.
+        """
+        return self.status == VerificationStatus.SUCCEEDED
 
     def get_function(self) -> CFunction:
         """Return the function being verified.


### PR DESCRIPTION
It is not enough to have a binary `succeeded` or `failed` value for specification results (a specification might be assumed).